### PR TITLE
fix cli script; asyncio.run must be called

### DIFF
--- a/python/s3daemon/s3daemon.py
+++ b/python/s3daemon/s3daemon.py
@@ -76,7 +76,7 @@ async def handle_client(client, reader, writer):
     log.info("%f %f sec", start, time.time() - start)
 
 
-async def main():
+async def go():
     """Start the server."""
     session = aiobotocore.session.get_session()
     async with session.create_client(
@@ -96,5 +96,10 @@ async def main():
             await server.serve_forever()
 
 
+def main():
+    """CLI script entry point."""
+    asyncio.run(go())
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
Resolves this error:

  Sep 06 17:34:19 jhoblitt-test2.dev.lsst.org systemd-s3daemon[696498]: <coroutine object main at 0x7faf99dd1f40>
  Sep 06 17:34:19 jhoblitt-test2.dev.lsst.org systemd-s3daemon[696498]: sys:1: RuntimeWarning: coroutine 'main' was never awaited
  Sep 06 17:34:19 jhoblitt-test2.dev.lsst.org systemd-s3daemon[696498]: RuntimeWarning: Enable tracemalloc to get the object allocation traceback